### PR TITLE
Updated size of titles

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -42,7 +42,7 @@ import blur from '/src/assets/img/bg.svg';
 					formats={['avif', 'webp']}
 				/>
 				<ul
-					class='text-7xl lg:text-8xl font-black grid gap-y-5 lg:gap-y-10 my-auto mt-10 lg:mt-0 content-start lg:content-center h-full max-h-[680px] text-white'>
+					class='text-8xl lg:text-7xl font-black grid gap-y-5 lg:gap-y-10 my-auto mt-10 lg:mt-0 content-start lg:content-center h-full max-h-[680px] text-white'>
 					<li>
 						<a
 							href='/'

--- a/src/components/Title.astro
+++ b/src/components/Title.astro
@@ -7,6 +7,6 @@ const { text } = Astro.props;
 ---
 
 <h1
-	class='mt-[6rem] px-2 md:px-0 lg:mt-0 text-7xl lg:text-8xl inline-block font-black bg-clip-text text-transparent bg-gradient-to-r from-accent-0 to-accent-0'>
+	class='mt-[6rem] px-2 md:px-0 lg:mt-0 text-7xl lg:text-6xl inline-block font-black bg-clip-text text-transparent bg-gradient-to-r from-accent-0 to-accent-0'>
 	{text}
 </h1>


### PR DESCRIPTION
# Description
- Text size of titles is too big

# Testing
- [x] Reduze title size to something you like

<img width="1440" alt="Screenshot 2024-03-01 at 11 14 32 PM" src="https://github.com/vratskyi/vratskyi.github.io/assets/92492748/d19ee1cf-cc7b-4b94-ad22-e8e9388758f2">
